### PR TITLE
Fix to work for in memory files, not just physically present

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(options) {
       return callback(new Error('Streaming not supported.'));
     }
 
-    if (file.stat.isDirectory()) {
+    if (file.stat && file.stat.isDirectory()) {
       debug('ignore directory %s', file.path);
       return callback();
     }


### PR DESCRIPTION
Not sure if I'm using the correct terminology, but basically im scping an in memory archive file and it doesn't have the stat object on it, thus raising an error. The code im using it with is like so:

```
gulp.src("#{TARGET_SERVER_VERSION_DIR}/**/*")
    .pipe(tar('release.tar'))
    .pipe(gzip())
    .pipe(rename(releaseArchiveName))
    .pipe(buffer())
    .pipe(scp({
      host: PROD_HOST,
      username: PROD_USERNAME,
      password: PROD_PASSWORD,
      dest: PROD_TMP
    }))
```
